### PR TITLE
Add support for NO_COLOR

### DIFF
--- a/lib/gitsh.rb
+++ b/lib/gitsh.rb
@@ -21,6 +21,7 @@ module Gitsh
   autoload :Tokenizer, "gitsh/tokenizer"
 
   HISTORY_FILE_PATH = (XDG::Data.new.home / "gitsh/history").freeze
+  USE_COLOR = ENV["NO_COLOR"].then { _1.nil? || _1.empty? }
 
   def self.run!
     # Set up shell history.
@@ -35,7 +36,7 @@ module Gitsh
     # Set up shell completions.
     Reline.autocompletion = true
     Reline.completion_proc = method(:completions)
-    Reline.output_modifier_proc = method(:highlight)
+    Reline.output_modifier_proc = method(:highlight) if USE_COLOR
 
     puts "# Welcome to gitsh!"
 

--- a/lib/gitsh/prompt.rb
+++ b/lib/gitsh/prompt.rb
@@ -29,37 +29,71 @@ module Gitsh
     def self.build(status:, branch: nil, changes: nil)
       string = +""
 
-      string << "gitsh".color(:aqua)
+      if USE_COLOR
+        string << "gitsh".color(:aqua)
 
-      if branch
-        string << "(" << branch.color(:mediumslateblue)
+        if branch
+          string << "(" << branch.color(:mediumslateblue)
 
-        if changes
-          string << "|"
+          if changes
+            string << "|"
 
-          if changes.unstaged_count.zero? && changes.staged_count.zero?
-            string << "✔".color(:green)
+            if changes.unstaged_count.zero? && changes.staged_count.zero?
+              string << "✔".color(:green)
+            end
+
+            if changes.staged_count.positive?
+              string << "●#{changes.staged_count}".color(:yellowgreen)
+            end
+
+            if changes.unstaged_count.positive?
+              string << "+#{changes.unstaged_count}".color(:blue)
+            end
           end
 
-          if changes.staged_count.positive?
-            string << "●#{changes.staged_count}".color(:yellowgreen)
-          end
-
-          if changes.unstaged_count.positive?
-            string << "+#{changes.unstaged_count}".color(:blue)
-          end
+          string << ")"
         end
 
-        string << ")"
+        if status.positive?
+          string << "[#{status}]".color(:crimson)
+        end
+
+        string << "> "
+
+        string.bold.freeze
+      else
+        string << "gitsh"
+
+        if branch
+          string << "(" << branch
+
+          if changes
+            string << "|"
+
+            if changes.unstaged_count.zero? && changes.staged_count.zero?
+              string << "✔"
+            end
+
+            if changes.staged_count.positive?
+              string << "●#{changes.staged_count}"
+            end
+
+            if changes.unstaged_count.positive?
+              string << "+#{changes.unstaged_count}"
+            end
+          end
+
+          string << ")"
+        end
+
+        if status.positive?
+          string << "[#{status}]"
+        end
+
+        string << "> "
+
+        string.freeze
       end
-
-      if status.positive?
-        string << "[#{status}]".color(:crimson)
-      end
-
-      string << "> "
-
-      string.bold.freeze
     end
     private_class_method :build
   end

--- a/spec/gitsh/prompt_spec.rb
+++ b/spec/gitsh/prompt_spec.rb
@@ -114,14 +114,19 @@ RSpec.describe Gitsh::Prompt do
         end
 
         context "with no changes" do
-          it "returns expected prompt" do
+          it "returns expected prompt", :aggregate_failures do
             expect(described_class.string(exit_code: failure))
               .to eq Rainbow("#{gitsh}(#{branch}|#{check})#{exit_code}> ").bold
+
+            stub_const("Gitsh::USE_COLOR", false)
+
+            expect(described_class.string(exit_code: failure))
+              .to eq "gitsh(main|✔)[127]> "
           end
         end
 
         context "with 2 staged changes" do
-          it "returns expected prompt" do
+          it "returns expected prompt", :aggregate_failures do
             # Two staged file changes
             FileUtils.touch "file1"
             FileUtils.touch "file2"
@@ -129,11 +134,16 @@ RSpec.describe Gitsh::Prompt do
 
             expect(described_class.string(exit_code: failure))
               .to eq Rainbow("#{gitsh}(#{branch}|#{staged})#{exit_code}> ").bold
+
+            stub_const("Gitsh::USE_COLOR", false)
+
+            expect(described_class.string(exit_code: failure))
+              .to eq "gitsh(main|●2)[127]> "
           end
         end
 
         context "with 1 unstaged change" do
-          it "returns expected prompt" do
+          it "returns expected prompt", :aggregate_failures do
             # Commit one file
             FileUtils.touch "file1"
             quiet_system("git add file1")
@@ -143,11 +153,16 @@ RSpec.describe Gitsh::Prompt do
 
             expect(described_class.string(exit_code: failure))
               .to eq Rainbow("#{gitsh}(#{branch}|#{unstaged})#{exit_code}> ").bold
+
+            stub_const("Gitsh::USE_COLOR", false)
+
+            expect(described_class.string(exit_code: failure))
+              .to eq "gitsh(main|+1)[127]> "
           end
         end
 
         context "with 2 staged changes and 1 unstaged change" do
-          it "returns expected prompt" do
+          it "returns expected prompt", :aggregate_failures do
             # Two staged file changes
             FileUtils.touch "file1"
             FileUtils.touch "file2"
@@ -157,6 +172,11 @@ RSpec.describe Gitsh::Prompt do
 
             expect(described_class.string(exit_code: failure))
               .to eq Rainbow("#{gitsh}(#{branch}|#{staged}#{unstaged})#{exit_code}> ").bold
+
+            stub_const("Gitsh::USE_COLOR", false)
+
+            expect(described_class.string(exit_code: failure))
+              .to eq "gitsh(main|●2+1)[127]> "
           end
         end
       end
@@ -166,9 +186,14 @@ RSpec.describe Gitsh::Prompt do
           in_temp_dir { example.run }
         end
 
-        it "returns default prompt string" do
+        it "returns default prompt string", :aggregate_failures do
           expect(described_class.string(exit_code: failure))
             .to eq Rainbow("#{gitsh}#{exit_code}> ").bold
+
+          stub_const("Gitsh::USE_COLOR", false)
+
+          expect(described_class.string(exit_code: failure))
+            .to eq "gitsh[127]> "
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Make sure that tests run with color by default.
+ENV.delete("NO_COLOR")
+
 require "gitsh"
 require "fileutils"
 require "rspec/snapshot"


### PR DESCRIPTION
This removes color and all other ANSI escape sequences from the prompt and highlighted output if the `NO_COLOR` environment variable is unset or empty.