### PR TITLE
Add token zipper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,6 @@ GEM
     standard-performance (1.6.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.23.0)
-    sumi (0.1.0)
     tty-which (0.5.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -90,7 +89,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   rspec-snapshot (~> 2.0.3)
   standard (~> 1.3)
-  sumi (~> 0.1.0)
 
 BUNDLED WITH
    2.6.3

--- a/gitsh.gemspec
+++ b/gitsh.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "standard", "~> 1.3"
-  spec.add_development_dependency "sumi", "~> 0.1.0"
   spec.add_development_dependency "rspec-snapshot", "~> 2.0.3"
   spec.add_development_dependency "prop_check", "~> 1.0.0"
 end

--- a/lib/gitsh/executor.rb
+++ b/lib/gitsh/executor.rb
@@ -28,6 +28,8 @@ module Gitsh
       class Exit < Base; end
     end
 
+    # Tokenize, parse and run the input line as a series of Git commands.
+    #
     # @param line [String]
     # @param out [IO] (default STDOUT)
     # @param err [IO] (default STDIN)

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -2,53 +2,48 @@
 
 module Gitsh
   module Parser
+    # Parse a line into a series of commands.
+    #
     # @param line [String]
     # @return [Array<Gitsh::Command::Base>]
     def self.parse(line)
       command_list = []
-      tokens = Tokenizer.tokenize(line)
-      return command_list if tokens.empty?
+      zipper = Tokenizer.tokenize(line)
+      return command_list if zipper.empty?
 
-      case tokens.first
-      in Token::String => token
-        command_list << Command::End.new(arguments: [token.content])
-      in Token::UnterminatedString => token
-        raise token.syntax_error("unterminated string")
-      in Token::PartialAction => token
-        raise token.syntax_error("expected '#{token.content * 2}' but got '#{token.content}' instead")
-      in token
-        raise token.parse_error("unexpected '#{token.content}' to start the line")
-      end
-
-      case tokens.last
-      in Token::And | Token::Or => token
-        raise token.parse_error("unexpected '#{token.content}' to end the line")
-      in Token::UnterminatedString => token
-        raise token.syntax_error("unterminated string")
-      else
-        # do nothing
-      end
-
-      tokens.each_cons(2) do |prev_token, next_token|
-        case [prev_token, next_token]
-        in Token::String, Token::String if prev_token.end_position == next_token.start_position
-          # Concatenate string content when they are adjacent to each other.
-          command_list.last.arguments.pop.tap do |prev_string|
-            command_list.last.arguments << prev_string + next_token.content
+      command_list << Command::End.new
+      zipper.each do |sub_zipper|
+        if sub_zipper.string_token?
+          if sub_zipper.before.string_token? && sub_zipper.gap_to_prev.zero?
+            # Concatenate string content when they are adjacent to each other.
+            command_list.last.arguments.pop.tap do |prev_string|
+              command_list.last.arguments << prev_string + sub_zipper.token.content
+            end
+          else
+            command_list.last.arguments << sub_zipper.token.content
           end
-        in _, Token::PartialAction
-          raise next_token.syntax_error("expected '#{next_token.content * 2}' but got '#{next_token.content}' instead")
-        in _, Token::String # Token is a string.
-          command_list.last.arguments << next_token.content
-        in Token::String, _ # Token is an action.
-          command_list << Token.to_action_command(next_token)
-        else
-          raise next_token.parse_error("expected a string after '#{prev_token.content}' but got '#{next_token.content}' instead")
+        elsif sub_zipper.action?
+          if sub_zipper.first?
+            raise sub_zipper.token.parse_error("unexpected '#{sub_zipper.token.content}' to start the line")
+          elsif sub_zipper.last? && !sub_zipper.end_token?
+            raise sub_zipper.token.parse_error("unexpected '#{sub_zipper.token.content}' to end the line")
+          elsif !sub_zipper.before.string_token?
+            raise sub_zipper.token.parse_error("expected a string after '#{sub_zipper.before.token.content}' but got '#{sub_zipper.token.content}' instead")
+          end
+
+          if sub_zipper.and_token?
+            command_list << Command::And.new
+          elsif sub_zipper.or_token?
+            command_list << Command::Or.new
+          elsif sub_zipper.end_token? && !sub_zipper.last?
+            command_list << Command::End.new
+          end
+        elsif sub_zipper.unterminated_string_token?
+          raise sub_zipper.token.syntax_error("unterminated string")
+        elsif sub_zipper.partial_action_token?
+          raise sub_zipper.token.syntax_error("expected '#{sub_zipper.token.content * 2}' but got '#{sub_zipper.token.content}' instead")
         end
       end
-
-      # Remove any trailing semicolons from the command list.
-      command_list.pop if command_list.last.is_a?(Command::End) && command_list.last.arguments.empty?
 
       command_list
     end

--- a/lib/gitsh/prompt.rb
+++ b/lib/gitsh/prompt.rb
@@ -4,6 +4,8 @@ require "rainbow/refinement"
 
 module Gitsh
   module Prompt
+    # Returns the shell prompt as a string.
+    #
     # @param exit_code [Integer]
     #
     # @return [String]

--- a/lib/gitsh/token_zipper.rb
+++ b/lib/gitsh/token_zipper.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module Gitsh
+  # This is a data structure representing an array of tokens with the index
+  # pointing at an individual token. The advantage of this data structure
+  # over an array is that it allows you to reference the tokens before
+  # and after the current token, adds a bunch of helper methods and
+  # allows data to be shared between tokens. When moving to another
+  # token it will return a copy of itself with the index, before and
+  # after values changed to minimize copying of strings.
+  class TokenZipper
+    include Enumerable
+
+    # @return [String]
+    attr_reader :source
+    # @return [Array<Gitsh::Token::Base>]
+    attr_reader :tokens
+    # @return [Integer]
+    attr_reader :index
+
+    # @param source [String] must be frozen
+    # @param tokens [Array<Gitsh::Token::Base>] must be frozen
+    # @param index [Integer]
+    # @param before [Gitsh::TokenZipper]
+    # @param after [Gitsh::TokenZipper]
+    def initialize(source:, tokens:, index: 0, before: nil, after: nil)
+      raise ArgumentError, ":source must be frozen" unless source.frozen?
+      raise ArgumentError, ":tokens must be frozen" unless tokens.frozen?
+
+      @source = source
+      @tokens = tokens
+      @index = index.clamp(-1, tokens.size)
+      @before = before if before
+      @after = after if after
+    end
+
+    # Returns the number of tokens.
+    #
+    # @return [Integer]
+    def size
+      @tokens.size
+    end
+
+    # Returns true if there are no tokens.
+    #
+    # @return [Boolean]
+    def empty?
+      @tokens.empty?
+    end
+
+    # Yields zippers representing each token starting from the beginning.
+    #
+    # @yield [Gitsh::TokenZipper]
+    def each
+      zipper = at(index: 0)
+
+      until zipper.tail?
+        yield zipper
+        zipper = zipper.after
+      end
+    end
+
+    # @return [Gitsh::TokenZipper] a new zipper representing the previous token
+    def before
+      @before ||= if head?
+        self
+      else
+        self.class.new(source: @source, tokens: @tokens, index: @index - 1, after: self)
+      end
+    end
+
+    # @return [Gitsh::TokenZipper] a new zipper representing the next token
+    def after
+      @after ||= if tail?
+        self
+      else
+        self.class.new(source: @source, tokens: @tokens, index: @index + 1, before: self)
+      end
+    end
+
+    # @param index [Integer]
+    #
+    # @return [Gitsh::TokenZipper] a new zipper representing the token at the index
+    def at(index:)
+      return self if index == @index
+      return before if index == @index - 1
+      return after if index == @index + 1
+
+      self.class.new(source: @source, tokens: @tokens, index: index)
+    end
+
+    # The gap between the end position of the current token and
+    # the start position of the next token.
+    #
+    # @return [Integer]
+    def gap_to_next
+      return 0 if head? || tail? || after.tail?
+
+      after.token.start_position - token.end_position
+    end
+
+    # The gap between the end position of the previous token and
+    # the start position of the current token.
+    #
+    # @return [Integer]
+    def gap_to_prev
+      return 0 if head? || tail? || before.head?
+
+      token.start_position - before.token.end_position
+    end
+
+    # Represents a zipper before the first token.
+    #
+    # @return [Boolean]
+    def head?
+      @index.negative?
+    end
+
+    # Represents a zipper after the last token.
+    #
+    # @return [Boolean]
+    def tail?
+      tokens.size <= @index
+    end
+
+    # Returns true if the zipper represents the first token.
+    #
+    # @return [Boolean]
+    def first?
+      !tail? && before.head?
+    end
+
+    # Returns the zipper associated with the first token or head.
+    #
+    # @return [Gitsh::Zipper]
+    def first
+      empty? ? at(index: -1) : at(index: 0)
+    end
+
+    # Returns true if the zipper represents the last token.
+    #
+    # @return [Boolean]
+    def last?
+      !head? && after.tail?
+    end
+
+    # Returns the zipper associated with the first token or head.
+    #
+    # @return [Gitsh::Zipper]
+    def last
+      empty? ? at(index: size) : at(index: size - 1)
+    end
+
+    # Returns the token at the current index or nil
+    # if the current index is the head or the tail.
+    #
+    # @return [Gitsh::Token::Base, nil]
+    def token
+      @tokens[@index] unless head? || tail?
+    end
+
+    # Returns true if the current token is a string.
+    #
+    # @return [Boolean]
+    def string_token?
+      token&.is_a?(Gitsh::Token::String)
+    end
+
+    # Returns true if the current token is the and action.
+    #
+    # @return [Boolean]
+    def and_token?
+      token&.is_a?(Gitsh::Token::And)
+    end
+
+    # Returns true if the current token is the or action.
+    #
+    # @return [Boolean]
+    def or_token?
+      token&.is_a?(Gitsh::Token::Or)
+    end
+
+    # Returns true if the current token is the end action.
+    #
+    # @return [Boolean]
+    def end_token?
+      token&.is_a?(Gitsh::Token::End)
+    end
+
+    # Returns true if the current token is a unterminated string.
+    #
+    # @return [Boolean]
+    def unterminated_string_token?
+      token&.is_a?(Gitsh::Token::UnterminatedString)
+    end
+
+    # Returns true if the current token is a partial action.
+    #
+    # @return [Boolean]
+    def partial_action_token?
+      token&.is_a?(Gitsh::Token::PartialAction)
+    end
+
+    # Returns true if the current token is the and, or or end action.
+    #
+    # @return [Boolean]
+    def action?
+      and_token? || or_token? || end_token?
+    end
+
+    # Returns true if the current token is a string and the previous token
+    # was at the head position, an action or a partial action.
+    #
+    # @return [Boolean]
+    def command?
+      (before.head? || before.action? || before.partial_action_token?) && string_token?
+    end
+
+    # Returns true if the current token is a command present in the
+    # all commands list.
+    #
+    # @return [Boolean]
+    def valid_command?
+      command? && Gitsh.all_commands.include?(token.content)
+    end
+  end
+end

--- a/spec/fixtures/snapshots/parses_a_long_series_of_commands.snap
+++ b/spec/fixtures/snapshots/parses_a_long_series_of_commands.snap
@@ -1,47 +1,57 @@
-[
-	{
-		line: "add ex.js && add ex.rb; git diff; git commit -m 'commit'",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["add", "ex.js"],
-			),
-			Gitsh::Command::And(
-				@arguments = ["add", "ex.rb"],
-			),
-			Gitsh::Command::End(
-				@arguments = ["git", "diff"],
-			),
-			Gitsh::Command::End(
-				@arguments = ["git", "commit", "-m", "commit"],
-			),
-		],
-	},
-	{
-		line: "git grep -q match_snapshot && git add .; git commit -m snapshots",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["git", "grep", "-q", "match_snapshot"],
-			),
-			Gitsh::Command::And(
-				@arguments = ["git", "add", "."],
-			),
-			Gitsh::Command::End(
-				@arguments = ["git", "commit", "-m", "snapshots"],
-			),
-		],
-	},
-	{
-		line: "git log -5 || git diff HEAD && git commit --amend",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["git", "log", "-5"],
-			),
-			Gitsh::Command::Or(
-				@arguments = ["git", "diff", "HEAD"],
-			),
-			Gitsh::Command::And(
-				@arguments = ["git", "commit", "--amend"],
-			),
-		],
-	},
-]
+---
+- :line: add ex.js && add ex.rb; git diff; git commit -m 'commit'
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - add
+    - ex.js
+  - !ruby/object:Gitsh::Command::And
+    arguments:
+    - add
+    - ex.rb
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - diff
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - commit
+    - "-m"
+    - commit
+- :line: git grep -q match_snapshot && git add .; git commit -m snapshots
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - grep
+    - "-q"
+    - match_snapshot
+  - !ruby/object:Gitsh::Command::And
+    arguments:
+    - git
+    - add
+    - "."
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - commit
+    - "-m"
+    - snapshots
+- :line: git log -5 || git diff HEAD && git commit --amend
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - log
+    - "-5"
+  - !ruby/object:Gitsh::Command::Or
+    arguments:
+    - git
+    - diff
+    - HEAD
+  - !ruby/object:Gitsh::Command::And
+    arguments:
+    - git
+    - commit
+    - "--amend"

--- a/spec/fixtures/snapshots/parses_a_single_command.snap
+++ b/spec/fixtures/snapshots/parses_a_single_command.snap
@@ -1,26 +1,24 @@
-[
-	{
-		line: "checkout auto_update_tap",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["checkout", "auto_update_tap"],
-			),
-		],
-	},
-	{
-		line: "git clone https://github.com/ruby/irb.git",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["git", "clone", "https://github.com/ruby/irb.git"],
-			),
-		],
-	},
-	{
-		line: "grep -C 5 -i -F match_snapshot",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["grep", "-C", "5", "-i", "-F", "match_snapshot"],
-			),
-		],
-	},
-]
+---
+- :line: checkout auto_update_tap
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - checkout
+    - auto_update_tap
+- :line: git clone https://github.com/ruby/irb.git
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - clone
+    - https://github.com/ruby/irb.git
+- :line: grep -C 5 -i -F match_snapshot
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - grep
+    - "-C"
+    - '5'
+    - "-i"
+    - "-F"
+    - match_snapshot

--- a/spec/fixtures/snapshots/parses_and_ignores_a_trailing_semicolon.snap
+++ b/spec/fixtures/snapshots/parses_and_ignores_a_trailing_semicolon.snap
@@ -1,26 +1,21 @@
-[
-	{
-		line: "git grep 'Github::API';",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["git", "grep", "Github::API"],
-			),
-		],
-	},
-	{
-		line: "diff head   ;  ",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["diff", "head"],
-			),
-		],
-	},
-	{
-		line: "git commit --amend;  ",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["git", "commit", "--amend"],
-			),
-		],
-	},
-]
+---
+- :line: git grep 'Github::API';
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - grep
+    - Github::API
+- :line: 'diff head   ;  '
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - diff
+    - head
+- :line: 'git commit --amend;  '
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - git
+    - commit
+    - "--amend"

--- a/spec/fixtures/snapshots/parses_multiple_commands.snap
+++ b/spec/fixtures/snapshots/parses_multiple_commands.snap
@@ -1,35 +1,34 @@
-[
-	{
-		line: "add --all; commit -m \"tmp\"",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["add", "--all"],
-			),
-			Gitsh::Command::End(
-				@arguments = ["commit", "-m", "tmp"],
-			),
-		],
-	},
-	{
-		line: "add --all || commit -m \"tmp\"",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["add", "--all"],
-			),
-			Gitsh::Command::Or(
-				@arguments = ["commit", "-m", "tmp"],
-			),
-		],
-	},
-	{
-		line: "add --all && commit -m \"tmp\"",
-		commands: [
-			Gitsh::Command::End(
-				@arguments = ["add", "--all"],
-			),
-			Gitsh::Command::And(
-				@arguments = ["commit", "-m", "tmp"],
-			),
-		],
-	},
-]
+---
+- :line: add --all; commit -m "tmp"
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - add
+    - "--all"
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - commit
+    - "-m"
+    - tmp
+- :line: add --all || commit -m "tmp"
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - add
+    - "--all"
+  - !ruby/object:Gitsh::Command::Or
+    arguments:
+    - commit
+    - "-m"
+    - tmp
+- :line: add --all && commit -m "tmp"
+  :commands:
+  - !ruby/object:Gitsh::Command::End
+    arguments:
+    - add
+    - "--all"
+  - !ruby/object:Gitsh::Command::And
+    arguments:
+    - commit
+    - "-m"
+    - tmp

--- a/spec/fixtures/snapshots/tokenizes_commands_without_arguments.snap
+++ b/spec/fixtures/snapshots/tokenizes_commands_without_arguments.snap
@@ -1,57 +1,46 @@
-[
-	{
-		line: "diff",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "diff",
-				@source = "diff",
-				@start_position = 0,
-				@end_position = 4,
-			),
-		],
-	},
-	{
-		line: "log",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "log",
-				@source = "log",
-				@start_position = 0,
-				@end_position = 3,
-			),
-		],
-	},
-	{
-		line: "branch",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "branch",
-				@source = "branch",
-				@start_position = 0,
-				@end_position = 6,
-			),
-		],
-	},
-	{
-		line: "commit",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "commit",
-				@source = "commit",
-				@start_position = 0,
-				@end_position = 6,
-			),
-		],
-	},
-	{
-		line: "cherry-pick",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "cherry-pick",
-				@source = "cherry-pick",
-				@start_position = 0,
-				@end_position = 11,
-			),
-		],
-	},
-]
+---
+- :line: diff
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: diff
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: diff
+      start_position: 0
+      end_position: 4
+    index: 0
+- :line: log
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: log
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: log
+      start_position: 0
+      end_position: 3
+    index: 0
+- :line: branch
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: branch
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: branch
+      start_position: 0
+      end_position: 6
+    index: 0
+- :line: commit
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: commit
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: commit
+      start_position: 0
+      end_position: 6
+    index: 0
+- :line: cherry-pick
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: cherry-pick
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: cherry-pick
+      start_position: 0
+      end_position: 11
+    index: 0

--- a/spec/fixtures/snapshots/tokenizes_double-quoted_strings.snap
+++ b/spec/fixtures/snapshots/tokenizes_double-quoted_strings.snap
@@ -1,111 +1,82 @@
-[
-	{
-		line: "grep   \" type : Tokenizer\"",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "grep",
-				@source = "grep   \" type : Tokenizer\"",
-				@start_position = 0,
-				@end_position = 4,
-			),
-			Gitsh::Token::String(
-				@content = " type : Tokenizer",
-				@source = "grep   \" type : Tokenizer\"",
-				@start_position = 7,
-				@end_position = 26,
-			),
-		],
-	},
-	{
-		line: "log   --grep   \"'exit' or 'quit'\"",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "log",
-				@source = "log   --grep   \"'exit' or 'quit'\"",
-				@start_position = 0,
-				@end_position = 3,
-			),
-			Gitsh::Token::String(
-				@content = "--grep",
-				@source = "log   --grep   \"'exit' or 'quit'\"",
-				@start_position = 6,
-				@end_position = 12,
-			),
-			Gitsh::Token::String(
-				@content = "'exit' or 'quit'",
-				@source = "log   --grep   \"'exit' or 'quit'\"",
-				@start_position = 15,
-				@end_position = 33,
-			),
-		],
-	},
-	{
-		line: "  add -- \"*.js\"",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "add",
-				@source = "  add -- \"*.js\"",
-				@start_position = 2,
-				@end_position = 5,
-			),
-			Gitsh::Token::String(
-				@content = "--",
-				@source = "  add -- \"*.js\"",
-				@start_position = 6,
-				@end_position = 8,
-			),
-			Gitsh::Token::String(
-				@content = "*.js",
-				@source = "  add -- \"*.js\"",
-				@start_position = 9,
-				@end_position = 15,
-			),
-		],
-	},
-	{
-		line: "log --author=\"One Punch Man\"",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "log",
-				@source = "log --author=\"One Punch Man\"",
-				@start_position = 0,
-				@end_position = 3,
-			),
-			Gitsh::Token::String(
-				@content = "--author=",
-				@source = "log --author=\"One Punch Man\"",
-				@start_position = 4,
-				@end_position = 13,
-			),
-			Gitsh::Token::String(
-				@content = "One Punch Man",
-				@source = "log --author=\"One Punch Man\"",
-				@start_position = 13,
-				@end_position = 28,
-			),
-		],
-	},
-	{
-		line: "commit -m \"Quote \\\" of all time\"",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "commit",
-				@source = "commit -m \"Quote \\\" of all time\"",
-				@start_position = 0,
-				@end_position = 6,
-			),
-			Gitsh::Token::String(
-				@content = "-m",
-				@source = "commit -m \"Quote \\\" of all time\"",
-				@start_position = 7,
-				@end_position = 9,
-			),
-			Gitsh::Token::String(
-				@content = "Quote \" of all time",
-				@source = "commit -m \"Quote \\\" of all time\"",
-				@start_position = 10,
-				@end_position = 32,
-			),
-		],
-	},
-]
+---
+- :line: 'grep   " type : Tokenizer"'
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: 'grep   " type : Tokenizer"'
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep   " type : Tokenizer"'
+      start_position: 0
+      end_position: 4
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep   " type : Tokenizer"'
+      start_position: 7
+      end_position: 26
+    index: 0
+- :line: log   --grep   "'exit' or 'quit'"
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: log   --grep   "'exit' or 'quit'"
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: log   --grep   "'exit' or 'quit'"
+      start_position: 0
+      end_position: 3
+    - !ruby/object:Gitsh::Token::String
+      source: log   --grep   "'exit' or 'quit'"
+      start_position: 6
+      end_position: 12
+    - !ruby/object:Gitsh::Token::String
+      source: log   --grep   "'exit' or 'quit'"
+      start_position: 15
+      end_position: 33
+    index: 0
+- :line: '  add -- "*.js"'
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: '  add -- "*.js"'
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: '  add -- "*.js"'
+      start_position: 2
+      end_position: 5
+    - !ruby/object:Gitsh::Token::String
+      source: '  add -- "*.js"'
+      start_position: 6
+      end_position: 8
+    - !ruby/object:Gitsh::Token::String
+      source: '  add -- "*.js"'
+      start_position: 9
+      end_position: 15
+    index: 0
+- :line: log --author="One Punch Man"
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: log --author="One Punch Man"
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: log --author="One Punch Man"
+      start_position: 0
+      end_position: 3
+    - !ruby/object:Gitsh::Token::String
+      source: log --author="One Punch Man"
+      start_position: 4
+      end_position: 13
+    - !ruby/object:Gitsh::Token::String
+      source: log --author="One Punch Man"
+      start_position: 13
+      end_position: 28
+    index: 0
+- :line: commit -m "Quote \" of all time"
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: commit -m "Quote \" of all time"
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m "Quote \" of all time"
+      start_position: 0
+      end_position: 6
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m "Quote \" of all time"
+      start_position: 7
+      end_position: 9
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m "Quote \" of all time"
+      start_position: 10
+      end_position: 32
+    index: 0

--- a/spec/fixtures/snapshots/tokenizes_single-quoted_strings.snap
+++ b/spec/fixtures/snapshots/tokenizes_single-quoted_strings.snap
@@ -1,105 +1,78 @@
-[
-	{
-		line: "grep 'type : Tokenizer'",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "grep",
-				@source = "grep 'type : Tokenizer'",
-				@start_position = 0,
-				@end_position = 4,
-			),
-			Gitsh::Token::String(
-				@content = "type : Tokenizer",
-				@source = "grep 'type : Tokenizer'",
-				@start_position = 5,
-				@end_position = 23,
-			),
-		],
-	},
-	{
-		line: "grep 'describe \".tokenize\" do'  ",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "grep",
-				@source = "grep 'describe \".tokenize\" do'  ",
-				@start_position = 0,
-				@end_position = 4,
-			),
-			Gitsh::Token::String(
-				@content = "describe \".tokenize\" do",
-				@source = "grep 'describe \".tokenize\" do'  ",
-				@start_position = 5,
-				@end_position = 30,
-			),
-		],
-	},
-	{
-		line: "add -- '*.js'",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "add",
-				@source = "add -- '*.js'",
-				@start_position = 0,
-				@end_position = 3,
-			),
-			Gitsh::Token::String(
-				@content = "--",
-				@source = "add -- '*.js'",
-				@start_position = 4,
-				@end_position = 6,
-			),
-			Gitsh::Token::String(
-				@content = "*.js",
-				@source = "add -- '*.js'",
-				@start_position = 7,
-				@end_position = 13,
-			),
-		],
-	},
-	{
-		line: " log --committer='Lawrence Kraft'",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "log",
-				@source = " log --committer='Lawrence Kraft'",
-				@start_position = 1,
-				@end_position = 4,
-			),
-			Gitsh::Token::String(
-				@content = "--committer=",
-				@source = " log --committer='Lawrence Kraft'",
-				@start_position = 5,
-				@end_position = 17,
-			),
-			Gitsh::Token::String(
-				@content = "Lawrence Kraft",
-				@source = " log --committer='Lawrence Kraft'",
-				@start_position = 17,
-				@end_position = 33,
-			),
-		],
-	},
-	{
-		line: "commit -m 'Quote \\' of some time'",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "commit",
-				@source = "commit -m 'Quote \\' of some time'",
-				@start_position = 0,
-				@end_position = 6,
-			),
-			Gitsh::Token::String(
-				@content = "-m",
-				@source = "commit -m 'Quote \\' of some time'",
-				@start_position = 7,
-				@end_position = 9,
-			),
-			Gitsh::Token::String(
-				@content = "Quote ' of some time",
-				@source = "commit -m 'Quote \\' of some time'",
-				@start_position = 10,
-				@end_position = 33,
-			),
-		],
-	},
-]
+---
+- :line: 'grep ''type : Tokenizer'''
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: 'grep ''type : Tokenizer'''
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep ''type : Tokenizer'''
+      start_position: 0
+      end_position: 4
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep ''type : Tokenizer'''
+      start_position: 5
+      end_position: 23
+    index: 0
+- :line: 'grep ''describe ".tokenize" do''  '
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: 'grep ''describe ".tokenize" do''  '
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep ''describe ".tokenize" do''  '
+      start_position: 0
+      end_position: 4
+    - !ruby/object:Gitsh::Token::String
+      source: 'grep ''describe ".tokenize" do''  '
+      start_position: 5
+      end_position: 30
+    index: 0
+- :line: add -- '*.js'
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: add -- '*.js'
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: add -- '*.js'
+      start_position: 0
+      end_position: 3
+    - !ruby/object:Gitsh::Token::String
+      source: add -- '*.js'
+      start_position: 4
+      end_position: 6
+    - !ruby/object:Gitsh::Token::String
+      source: add -- '*.js'
+      start_position: 7
+      end_position: 13
+    index: 0
+- :line: " log --committer='Lawrence Kraft'"
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: " log --committer='Lawrence Kraft'"
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: " log --committer='Lawrence Kraft'"
+      start_position: 1
+      end_position: 4
+    - !ruby/object:Gitsh::Token::String
+      source: " log --committer='Lawrence Kraft'"
+      start_position: 5
+      end_position: 17
+    - !ruby/object:Gitsh::Token::String
+      source: " log --committer='Lawrence Kraft'"
+      start_position: 17
+      end_position: 33
+    index: 0
+- :line: commit -m 'Quote \' of some time'
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: commit -m 'Quote \' of some time'
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m 'Quote \' of some time'
+      start_position: 0
+      end_position: 6
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m 'Quote \' of some time'
+      start_position: 7
+      end_position: 9
+    - !ruby/object:Gitsh::Token::String
+      source: commit -m 'Quote \' of some time'
+      start_position: 10
+      end_position: 33
+    index: 0

--- a/spec/fixtures/snapshots/tokenizes_strings_with_multiple_actions.snap
+++ b/spec/fixtures/snapshots/tokenizes_strings_with_multiple_actions.snap
@@ -1,149 +1,104 @@
-[
-	{
-		line: "one && two; three || four",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "one",
-				@source = "one && two; three || four",
-				@start_position = 0,
-				@end_position = 3,
-			),
-			Gitsh::Token::And(
-				@content = "&&",
-				@source = "one && two; three || four",
-				@start_position = 4,
-				@end_position = 6,
-			),
-			Gitsh::Token::String(
-				@content = "two",
-				@source = "one && two; three || four",
-				@start_position = 7,
-				@end_position = 10,
-			),
-			Gitsh::Token::End(
-				@content = ";",
-				@source = "one && two; three || four",
-				@start_position = 10,
-				@end_position = 11,
-			),
-			Gitsh::Token::String(
-				@content = "three",
-				@source = "one && two; three || four",
-				@start_position = 12,
-				@end_position = 17,
-			),
-			Gitsh::Token::Or(
-				@content = "||",
-				@source = "one && two; three || four",
-				@start_position = 18,
-				@end_position = 20,
-			),
-			Gitsh::Token::String(
-				@content = "four",
-				@source = "one && two; three || four",
-				@start_position = 21,
-				@end_position = 25,
-			),
-		],
-	},
-	{
-		line: "&&   &&&&;||",
-		tokens: [
-			Gitsh::Token::And(
-				@content = "&&",
-				@source = "&&   &&&&;||",
-				@start_position = 0,
-				@end_position = 2,
-			),
-			Gitsh::Token::And(
-				@content = "&&",
-				@source = "&&   &&&&;||",
-				@start_position = 5,
-				@end_position = 7,
-			),
-			Gitsh::Token::And(
-				@content = "&&",
-				@source = "&&   &&&&;||",
-				@start_position = 7,
-				@end_position = 9,
-			),
-			Gitsh::Token::End(
-				@content = ";",
-				@source = "&&   &&&&;||",
-				@start_position = 9,
-				@end_position = 10,
-			),
-			Gitsh::Token::Or(
-				@content = "||",
-				@source = "&&   &&&&;||",
-				@start_position = 10,
-				@end_position = 12,
-			),
-		],
-	},
-	{
-		line: "one two &&||||; three four ;;",
-		tokens: [
-			Gitsh::Token::String(
-				@content = "one",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 0,
-				@end_position = 3,
-			),
-			Gitsh::Token::String(
-				@content = "two",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 4,
-				@end_position = 7,
-			),
-			Gitsh::Token::And(
-				@content = "&&",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 8,
-				@end_position = 10,
-			),
-			Gitsh::Token::Or(
-				@content = "||",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 10,
-				@end_position = 12,
-			),
-			Gitsh::Token::Or(
-				@content = "||",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 12,
-				@end_position = 14,
-			),
-			Gitsh::Token::End(
-				@content = ";",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 14,
-				@end_position = 15,
-			),
-			Gitsh::Token::String(
-				@content = "three",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 16,
-				@end_position = 21,
-			),
-			Gitsh::Token::String(
-				@content = "four",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 22,
-				@end_position = 26,
-			),
-			Gitsh::Token::End(
-				@content = ";",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 27,
-				@end_position = 28,
-			),
-			Gitsh::Token::End(
-				@content = ";",
-				@source = "one two &&||||; three four ;;",
-				@start_position = 28,
-				@end_position = 29,
-			),
-		],
-	},
-]
+---
+- :line: one && two; three || four
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: one && two; three || four
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: one && two; three || four
+      start_position: 0
+      end_position: 3
+    - !ruby/object:Gitsh::Token::And
+      source: one && two; three || four
+      start_position: 4
+      end_position: 6
+    - !ruby/object:Gitsh::Token::String
+      source: one && two; three || four
+      start_position: 7
+      end_position: 10
+    - !ruby/object:Gitsh::Token::End
+      source: one && two; three || four
+      start_position: 10
+      end_position: 11
+    - !ruby/object:Gitsh::Token::String
+      source: one && two; three || four
+      start_position: 12
+      end_position: 17
+    - !ruby/object:Gitsh::Token::Or
+      source: one && two; three || four
+      start_position: 18
+      end_position: 20
+    - !ruby/object:Gitsh::Token::String
+      source: one && two; three || four
+      start_position: 21
+      end_position: 25
+    index: 0
+- :line: "&&   &&&&;||"
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: "&&   &&&&;||"
+    tokens:
+    - !ruby/object:Gitsh::Token::And
+      source: "&&   &&&&;||"
+      start_position: 0
+      end_position: 2
+    - !ruby/object:Gitsh::Token::And
+      source: "&&   &&&&;||"
+      start_position: 5
+      end_position: 7
+    - !ruby/object:Gitsh::Token::And
+      source: "&&   &&&&;||"
+      start_position: 7
+      end_position: 9
+    - !ruby/object:Gitsh::Token::End
+      source: "&&   &&&&;||"
+      start_position: 9
+      end_position: 10
+    - !ruby/object:Gitsh::Token::Or
+      source: "&&   &&&&;||"
+      start_position: 10
+      end_position: 12
+    index: 0
+- :line: one two &&||||; three four ;;
+  :tokens: !ruby/object:Gitsh::TokenZipper
+    source: one two &&||||; three four ;;
+    tokens:
+    - !ruby/object:Gitsh::Token::String
+      source: one two &&||||; three four ;;
+      start_position: 0
+      end_position: 3
+    - !ruby/object:Gitsh::Token::String
+      source: one two &&||||; three four ;;
+      start_position: 4
+      end_position: 7
+    - !ruby/object:Gitsh::Token::And
+      source: one two &&||||; three four ;;
+      start_position: 8
+      end_position: 10
+    - !ruby/object:Gitsh::Token::Or
+      source: one two &&||||; three four ;;
+      start_position: 10
+      end_position: 12
+    - !ruby/object:Gitsh::Token::Or
+      source: one two &&||||; three four ;;
+      start_position: 12
+      end_position: 14
+    - !ruby/object:Gitsh::Token::End
+      source: one two &&||||; three four ;;
+      start_position: 14
+      end_position: 15
+    - !ruby/object:Gitsh::Token::String
+      source: one two &&||||; three four ;;
+      start_position: 16
+      end_position: 21
+    - !ruby/object:Gitsh::Token::String
+      source: one two &&||||; three four ;;
+      start_position: 22
+      end_position: 26
+    - !ruby/object:Gitsh::Token::End
+      source: one two &&||||; three four ;;
+      start_position: 27
+      end_position: 28
+    - !ruby/object:Gitsh::Token::End
+      source: one two &&||||; three four ;;
+      start_position: 28
+      end_position: 29
+    index: 0

--- a/spec/gitsh/tokenizer_spec.rb
+++ b/spec/gitsh/tokenizer_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Gitsh::Tokenizer do
         %(checkout -b 'skldfjsd\\'skdlfjsdkf),
         %(commit -m "sdfjsdfsdf\\"sdk  djf)
       ].each do |line|
-        expect(described_class.tokenize(line))
-          .to end_with(Gitsh::Token::UnterminatedString)
+        expect(described_class.tokenize(line).last)
+          .to be_an_unterminated_string_token
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Gitsh::Tokenizer do
         %(branch -D sdkfsdlk|jdsfkjds),
         %(checkout -b skdlfjsdkf|)
       ].each do |line|
-        expect(described_class.tokenize(line))
+        expect(described_class.tokenize(line).tokens)
           .to include(Gitsh::Token::PartialAction)
       end
     end
@@ -79,10 +79,10 @@ RSpec.describe Gitsh::Tokenizer do
           "first #{action}second",
           "first#{action}second"
         ].each do |line|
-          tokens = described_class.tokenize(line)
+          zipper = described_class.tokenize(line)
 
-          expect(tokens.map(&:class)).to eq([Gitsh::Token::String, klass, Gitsh::Token::String])
-          expect(tokens.map(&:content)).to eq(["first", action, "second"])
+          expect(zipper.tokens.map(&:class)).to eq([Gitsh::Token::String, klass, Gitsh::Token::String])
+          expect(zipper.tokens.map(&:content)).to eq(["first", action, "second"])
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,16 @@ ENV.delete("NO_COLOR")
 
 require "gitsh"
 require "fileutils"
-require "rspec/snapshot"
 require "prop_check"
-require "sumi"
-require "date" # needed for "sumi"
+require "rspec/snapshot"
+require "yaml"
+
+# For the snapshot testing library.
+class YAMLSerializer
+  def dump(object)
+    YAML.dump(object)
+  end
+end
 
 module Gitsh
   # Additional test helper functions.
@@ -17,19 +23,9 @@ module Gitsh
     #
     # @return [String] highlighted string
     def self.highlight(line)
-      tokens = Gitsh::Tokenizer.tokenize(line)
-      Gitsh::Highlighter.from_tokens(tokens)
+      zipper = Gitsh::Tokenizer.tokenize(line)
+      Gitsh::Highlighter.from_token_zipper(zipper)
     end
-  end
-end
-
-# Serializes values in a human readable way for snapshots using the
-# awesome_print gem
-class SumiSerializer
-  # @param [*] value The value to serialize.
-  # @return [String] The serialized value.
-  def dump(value)
-    Sumi.inspect(value)
   end
 end
 
@@ -117,7 +113,7 @@ RSpec.configure do |config|
   # Defaults to using the awesome_print gem to serialize values for snapshots
   #
   # Set this value to use a custom snapshot serializer
-  config.snapshot_serializer = SumiSerializer
+  config.snapshot_serializer = YAMLSerializer
 end
 
 # Copied from `Library/Homebrew/dev-cmd/tests.rb`.


### PR DESCRIPTION
This zipper better encapsulates parsing logic than using a bare array and is easier to reason about since it's immutable.

I also updated the snapshot formatter to just use `YAML.dump` since that's much simpler than using another library for formatting and is readable enough for my purposes.