### PR TITLE
Exit gracefully from REPL

### DIFF
--- a/lib/gitsh/executor.rb
+++ b/lib/gitsh/executor.rb
@@ -60,11 +60,7 @@ module Gitsh
           skip_to_end = false
         end
 
-        case command.arguments.first
-        when "exit", "quit"
-          out.puts "Have a nice day!"
-          return Result::Exit.new(exit_code: 0)
-        end
+        raise ExitError if %w[exit quit].include?(command.arguments.first)
 
         exit_code = Git.run(
           command.arguments,

--- a/spec/gitsh/executor_spec.rb
+++ b/spec/gitsh/executor_spec.rb
@@ -137,19 +137,15 @@ RSpec.describe Gitsh::Executor do
     # Exit
     #
     it "exits successfully" do
-      expect(described_class.execute_line(line: "exit", out: out, err: err))
-        .to eq(Gitsh::Executor::Result::Exit.new(exit_code: 0))
-
-      expect(out_str).to start_with("Have a nice day!")
-      expect(err.size).to eq(0)
+      expect do
+        described_class.execute_line(line: "exit", out: out, err: err)
+      end.to raise_error(Gitsh::ExitError)
     end
 
     it "quits successfully" do
-      expect(described_class.execute_line(line: "quit", out: out, err: err))
-        .to eq(Gitsh::Executor::Result::Exit.new(exit_code: 0))
-
-      expect(out_str).to start_with("Have a nice day!")
-      expect(err.size).to eq(0)
+      expect do
+        described_class.execute_line(line: "quit", out: out, err: err)
+      end.to raise_error(Gitsh::ExitError)
     end
 
     #


### PR DESCRIPTION
Now it is possible to exit gracefully from the REPL with the "exit" or "quit" commands along with the ctrl-d and ctrl-c signals.

Fixes #22 