### PR TITLE
Improve internal command discoverability

### DIFF
--- a/exe/igitsh
+++ b/exe/igitsh
@@ -11,8 +11,7 @@ OptionParser.new do |parser|
   igitsh -- an interactive shell for git
 
   This shell includes completions and history.
-  Run any `git` command without prefixing `git`
-  and just `exit` when you're done.
+  Run any `git` command without prefixing `git`.
 
   Options:
   BANNER

--- a/lib/igitsh.rb
+++ b/lib/igitsh.rb
@@ -32,6 +32,7 @@ module Igitsh
   autoload :Parser, "igitsh/parser"
   autoload :Prompt, "igitsh/prompt"
   autoload :Stringer, "igitsh/stringer"
+  autoload :Terminal, "igitsh/terminal"
   autoload :Token, "igitsh/token"
   autoload :TokenZipper, "igitsh/token_zipper"
   autoload :Tokenizer, "igitsh/tokenizer"
@@ -61,11 +62,8 @@ module Igitsh
     Reline.output_modifier_proc = Highlighter::CALLBACK if USE_COLOR
 
     puts <<~WELCOME
-      # Welcome to igitsh!
-      #
-      # (enter :commands to list all commands)
-      # (enter :help for more information)
-      # (enter :exit to exit)
+      #                 Welcome to igitsh!
+      # (enter :exit to exit and :commands to list all commands)
     WELCOME
 
     exit_code = 0
@@ -110,7 +108,7 @@ module Igitsh
   def self.command_name?(name)
     Git.command_set.include?(name) ||
       Git.aliases.include?(name) ||
-      Commander.name_to_command.include?(name)
+      Commander.name_to_internal_command.include?(name)
   end
 
   # @return [Array<String>]

--- a/lib/igitsh.rb
+++ b/lib/igitsh.rb
@@ -60,7 +60,13 @@ module Igitsh
     # Set up syntax highlighting.
     Reline.output_modifier_proc = Highlighter::CALLBACK if USE_COLOR
 
-    puts "# Welcome to igitsh!"
+    puts <<~WELCOME
+      # Welcome to igitsh!
+      #
+      # (enter :commands to list all commands)
+      # (enter :help for more information)
+      # (enter :exit to exit)
+    WELCOME
 
     exit_code = 0
 

--- a/lib/igitsh/commander.rb
+++ b/lib/igitsh/commander.rb
@@ -89,12 +89,14 @@ module Igitsh
         #
         # @return [String]
         def name
+          raise NotImplementedError
         end
 
         # Override in subclass.
         #
         # @return [String]
         def description
+          raise NotImplementedError
         end
 
         # Callback to define help option on all subclasses.
@@ -104,8 +106,8 @@ module Igitsh
           subclass.def_option(
             name: "--help",
             description: "Show this help page."
-          ) do |*, out:, **|
-            out.puts subclass.help_text
+          ) do
+            Terminal.page subclass.help_text
             SUCCESS_CODE
           end
         end
@@ -156,7 +158,7 @@ module Igitsh
             end.join("\n")
 
             <<~HELP
-              GITSH-#{name.delete_prefix(":").upcase}(1)
+              IGITSH-#{name.delete_prefix(":").upcase}(1)
 
               NAME
               #{Stringer.indent_by(name, size: 6)}
@@ -201,24 +203,6 @@ module Igitsh
           ).freeze
 
           nil
-        end
-      end
-    end
-
-    class Exit < Base
-      def_default(description: "Exit the program.") do
-        raise ExitError
-      end
-
-      class << self
-        # @return [String]
-        def name
-          ":exit"
-        end
-
-        # @return [String]
-        def description
-          "Gracefully exit the program. This is equivalent to ctrl-c or ctrl-d."
         end
       end
     end
@@ -282,39 +266,55 @@ module Igitsh
           DESCRIPTION
         end
       end
+    end
 
-      class History < Base
-        def_option(
-          name: "--list",
-          description: "Browse your Igitsh shell history from newest to oldest."
-        ) do
-          require "tty-pager"
+    class Exit < Base
+      def_default(description: "Exit the program.") do
+        raise ExitError
+      end
 
-          TTY::Pager.page do |pager|
-            Reline::HISTORY.reverse_each do |line|
-              pager.write("> ")
-              if USE_COLOR
-                highlighted_line = Highlighter.from_line(line, complete: true)
-                pager.puts(highlighted_line)
-              else
-                pager.puts(line)
-              end
-            end
-          end
-
-          SUCCESS_CODE
+      class << self
+        # @return [String]
+        def name
+          ":exit"
         end
 
-        class << self
-          # @return [String]
-          def name
-            ":history"
-          end
+        # @return [String]
+        def description
+          "Gracefully exit the program. This is equivalent to ctrl-c or ctrl-d."
+        end
+      end
+    end
 
-          # @return [String]
-          def description
-            "Browse your Igitsh shell history with syntax highlighting."
+    class History < Base
+      def_option(
+        name: "--list",
+        description: "Browse your Igitsh shell history from newest to oldest."
+      ) do
+        Terminal.page do |pager|
+          Reline::HISTORY.reverse_each do |line|
+            pager.write("> ")
+            if USE_COLOR
+              highlighted_line = Highlighter.from_line(line, complete: true)
+              pager.puts(highlighted_line)
+            else
+              pager.puts(line)
+            end
           end
+        end
+
+        SUCCESS_CODE
+      end
+
+      class << self
+        # @return [String]
+        def name
+          ":history"
+        end
+
+        # @return [String]
+        def description
+          "Browse your Igitsh shell history with syntax highlighting."
         end
       end
     end
@@ -337,16 +337,39 @@ module Igitsh
       end
     end
 
+    class Help
+      # @param arguments [Array<String>]
+      # @params out [IO]
+      # @params err [IO]
+      #
+      # @return [Integer]
+      def initialize(arguments, out:, err:)
+        @arguments = arguments.freeze
+        @out = out
+        @err = err
+      end
+
+      # @return [Integer]
+      def run
+        case @arguments
+        in ["help", command] if ::Igitsh::Commander.internal_command_names.include?(command)
+          ::Igitsh::Commander.from_name(command).new([command, "--help"], out: @out, err: @err).run
+        else
+          ::Igitsh::Git.run(@arguments, out: @out, err: @err)
+        end
+      end
+    end
+
     # @param name [String]
     #
     # @return [Igitsh::Commander::Base, Igitsh::Commander::Git]
     def self.from_name(name)
-      name_to_command.fetch(name, Git)
+      (name == "help") ? Help : name_to_internal_command.fetch(name, Git)
     end
 
-    # @return [Hash<String, Class>]
-    def self.name_to_command
-      @name_to_command ||= internal_commands
+    # @return [Hash<String, Igitsh::Commander::Base>]
+    def self.name_to_internal_command
+      @name_to_internal_command ||= internal_commands
         .to_h { |subclass| [subclass.name, subclass] }
         .freeze
     end

--- a/lib/igitsh/git.rb
+++ b/lib/igitsh/git.rb
@@ -46,13 +46,18 @@ module Igitsh
     }x
     private_constant :COMMAND_DESCRIPTION_REGEX
 
+    # @return [String]
+    def self.raw_command_descriptions
+      out_str, _err_str, _status = Open3.capture3("git help --all")
+      out_str.strip
+    end
+
     # @return [Hash<String, String>] hash of command to description
     def self.command_descriptions
-      @command_descriptions ||= begin
-        out_str, _err_str, _status = Open3.capture3("git help --all")
-        description_page = out_str.strip
-        description_page.scan(COMMAND_DESCRIPTION_REGEX).to_h
-      end.freeze
+      @command_descriptions ||= raw_command_descriptions
+        .scan(COMMAND_DESCRIPTION_REGEX)
+        .to_h
+        .freeze
     end
 
     Changes = Struct.new(:staged_count, :unstaged_count, keyword_init: true)

--- a/lib/igitsh/hinter.rb
+++ b/lib/igitsh/hinter.rb
@@ -70,7 +70,7 @@ module Igitsh
       description = if Git.command_descriptions.include?(completion)
         Git.command_descriptions.fetch(completion)
       elsif Commander.internal_command_names.include?(completion)
-        Commander.name_to_command.fetch(completion).description
+        Commander.name_to_internal_command.fetch(completion).description
       end
 
       if description

--- a/lib/igitsh/terminal.rb
+++ b/lib/igitsh/terminal.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "tty-pager"
+
+module Igitsh
+  module Terminal
+    # @param content [String, nil]
+    # @block for incrementally adding content to the pager
+    def self.page(content = nil, &block)
+      if block
+        TTY::Pager.page(&block)
+      elsif content
+        command = [
+          "less",
+          "--clear-screen", # make sure everything is top-justified
+          "--tilde", # don't show tildes on lines after the output
+          "--prompt='(press h for help or q to quit)'"
+        ].join(" ")
+
+        pager = TTY::Pager::SystemPager.new(command: command)
+        pager.page(content)
+      else
+        raise ArgumentError, "no content or block specified"
+      end
+    end
+  end
+end

--- a/lib/igitsh/token_zipper.rb
+++ b/lib/igitsh/token_zipper.rb
@@ -369,7 +369,7 @@ module Igitsh
 
         options.find { |option| !option.suffix.empty? }&.suffix
       elsif current_command.valid_internal_command?
-        internal_command = Commander.name_to_command[current_command.token.content]
+        internal_command = Commander.name_to_internal_command[current_command.token.content]
         return unless internal_command
 
         option = internal_command.option_by_prefix[token.raw_content]

--- a/spec/fixtures/snapshots/internal_command_help_pages.snap
+++ b/spec/fixtures/snapshots/internal_command_help_pages.snap
@@ -1,6 +1,6 @@
 ---
 ":history": |
-  GITSH-HISTORY(1)
+  IGITSH-HISTORY(1)
 
   NAME
         :history
@@ -15,8 +15,23 @@
               oldest.
         --help
               Show this help page.
+":exit": |
+  IGITSH-EXIT(1)
+
+  NAME
+        :exit
+
+  DESCRIPTION
+        Gracefully exit the program. This is equivalent
+        to ctrl-c or ctrl-d.
+
+  OPTIONS
+        *
+              Exit the program.
+        --help
+              Show this help page.
 ":alias": |
-  GITSH-ALIAS(1)
+  IGITSH-ALIAS(1)
 
   NAME
         :alias
@@ -37,20 +52,5 @@
               List all local and global aliases.
         --local <name> <command>
               Set or unset a local alias for the current repo.
-        --help
-              Show this help page.
-":exit": |
-  GITSH-EXIT(1)
-
-  NAME
-        :exit
-
-  DESCRIPTION
-        Gracefully exit the program. This is equivalent
-        to ctrl-c or ctrl-d.
-
-  OPTIONS
-        *
-              Exit the program.
         --help
               Show this help page.

--- a/spec/fixtures/snapshots/internal_command_help_pages.snap
+++ b/spec/fixtures/snapshots/internal_command_help_pages.snap
@@ -10,7 +10,7 @@
         highlighting.
 
   OPTIONS
-        --list
+        *
               Browse your Igitsh shell history from newest to
               oldest.
         --help
@@ -28,6 +28,21 @@
   OPTIONS
         *
               Exit the program.
+        --help
+              Show this help page.
+":commands": |
+  IGITSH-COMMANDS(1)
+
+  NAME
+        :commands
+
+  DESCRIPTION
+        List all internal and external commands along
+        with descriptions.
+
+  OPTIONS
+        *
+              List all commands.
         --help
               Show this help page.
 ":alias": |

--- a/spec/fixtures/snapshots/internal_command_hints.snap
+++ b/spec/fixtures/snapshots/internal_command_hints.snap
@@ -9,6 +9,10 @@
 - "  that aliases are"
 - "  available outside of"
 - "  Igitsh once defined."
+":commands":
+- "  List all internal and"
+- "  external commands along"
+- "  with descriptions."
 ":exit":
 - "  Gracefully exit the"
 - "  program. This is"

--- a/spec/fixtures/snapshots/internal_command_list_output.snap
+++ b/spec/fixtures/snapshots/internal_command_list_output.snap
@@ -1,0 +1,191 @@
+Igitsh Internal Commands
+   :alias                  Create local and global Git aliases for common command combinations.
+   :commands               List all internal and external commands along with descriptions.
+   :exit                   Gracefully exit the program. This is equivalent to ctrl-c or ctrl-d.
+   :history                Browse your Igitsh shell history with syntax highlighting.
+
+See 'git help <command>' to read about a specific subcommand
+
+Main Porcelain Commands
+   add                     Add file contents to the index
+   am                      Apply a series of patches from a mailbox
+   archive                 Create an archive of files from a named tree
+   bisect                  Use binary search to find the commit that introduced a bug
+   branch                  List, create, or delete branches
+   bundle                  Move objects and refs by archive
+   checkout                Switch branches or restore working tree files
+   cherry-pick             Apply the changes introduced by some existing commits
+   citool                  Graphical alternative to git-commit
+   clean                   Remove untracked files from the working tree
+   clone                   Clone a repository into a new directory
+   commit                  Record changes to the repository
+   describe                Give an object a human readable name based on an available ref
+   diff                    Show changes between commits, commit and working tree, etc
+   fetch                   Download objects and refs from another repository
+   format-patch            Prepare patches for e-mail submission
+   gc                      Cleanup unnecessary files and optimize the local repository
+   gitk                    The Git repository browser
+   grep                    Print lines matching a pattern
+   gui                     A portable graphical interface to Git
+   init                    Create an empty Git repository or reinitialize an existing one
+   log                     Show commit logs
+   maintenance             Run tasks to optimize Git repository data
+   merge                   Join two or more development histories together
+   mv                      Move or rename a file, a directory, or a symlink
+   notes                   Add or inspect object notes
+   pull                    Fetch from and integrate with another repository or a local branch
+   push                    Update remote refs along with associated objects
+   range-diff              Compare two commit ranges (e.g. two versions of a branch)
+   rebase                  Reapply commits on top of another base tip
+   reset                   Reset current HEAD to the specified state
+   restore                 Restore working tree files
+   revert                  Revert some existing commits
+   rm                      Remove files from the working tree and from the index
+   scalar                  A tool for managing large Git repositories
+   shortlog                Summarize 'git log' output
+   show                    Show various types of objects
+   sparse-checkout         Reduce your working tree to a subset of tracked files
+   stash                   Stash the changes in a dirty working directory away
+   status                  Show the working tree status
+   submodule               Initialize, update or inspect submodules
+   switch                  Switch branches
+   tag                     Create, list, delete or verify a tag object signed with GPG
+   worktree                Manage multiple working trees
+
+Ancillary Commands / Manipulators
+   config                  Get and set repository or global options
+   fast-export             Git data exporter
+   fast-import             Backend for fast Git data importers
+   filter-branch           Rewrite branches
+   mergetool               Run merge conflict resolution tools to resolve merge conflicts
+   pack-refs               Pack heads and tags for efficient repository access
+   prune                   Prune all unreachable objects from the object database
+   reflog                  Manage reflog information
+   remote                  Manage set of tracked repositories
+   repack                  Pack unpacked objects in a repository
+   replace                 Create, list, delete refs to replace objects
+
+Ancillary Commands / Interrogators
+   annotate                Annotate file lines with commit information
+   blame                   Show what revision and author last modified each line of a file
+   bugreport               Collect information for user to file a bug report
+   count-objects           Count unpacked number of objects and their disk consumption
+   diagnose                Generate a zip archive of diagnostic information
+   difftool                Show changes using common diff tools
+   fsck                    Verifies the connectivity and validity of the objects in the database
+   gitweb                  Git web interface (web frontend to Git repositories)
+   help                    Display help information about Git
+   instaweb                Instantly browse your working repository in gitweb
+   merge-tree              Perform merge without touching index or working tree
+   rerere                  Reuse recorded resolution of conflicted merges
+   show-branch             Show branches and their commits
+   verify-commit           Check the GPG signature of commits
+   verify-tag              Check the GPG signature of tags
+   version                 Display version information about Git
+   whatchanged             Show logs with differences each commit introduces
+
+Interacting with Others
+   archimport              Import a GNU Arch repository into Git
+   cvsexportcommit         Export a single commit to a CVS checkout
+   cvsimport               Salvage your data out of another SCM people love to hate
+   cvsserver               A CVS server emulator for Git
+   imap-send               Send a collection of patches from stdin to an IMAP folder
+   p4                      Import from and submit to Perforce repositories
+   quiltimport             Applies a quilt patchset onto the current branch
+   request-pull            Generates a summary of pending changes
+   send-email              Send a collection of patches as emails
+   svn                     Bidirectional operation between a Subversion repository and Git
+
+Low-level Commands / Manipulators
+   apply                   Apply a patch to files and/or to the index
+   checkout-index          Copy files from the index to the working tree
+   commit-graph            Write and verify Git commit-graph files
+   commit-tree             Create a new commit object
+   hash-object             Compute object ID and optionally create an object from a file
+   index-pack              Build pack index file for an existing packed archive
+   merge-file              Run a three-way file merge
+   merge-index             Run a merge for files needing merging
+   mktag                   Creates a tag object with extra validation
+   mktree                  Build a tree-object from ls-tree formatted text
+   multi-pack-index        Write and verify multi-pack-indexes
+   pack-objects            Create a packed archive of objects
+   prune-packed            Remove extra objects that are already in pack files
+   read-tree               Reads tree information into the index
+   symbolic-ref            Read, modify and delete symbolic refs
+   unpack-objects          Unpack objects from a packed archive
+   update-index            Register file contents in the working tree to the index
+   update-ref              Update the object name stored in a ref safely
+   write-tree              Create a tree object from the current index
+
+Low-level Commands / Interrogators
+   cat-file                Provide contents or details of repository objects
+   cherry                  Find commits yet to be applied to upstream
+   diff-files              Compares files in the working tree and the index
+   diff-index              Compare a tree to the working tree or index
+   diff-tree               Compares the content and mode of blobs found via two tree objects
+   for-each-ref            Output information on each ref
+   for-each-repo           Run a Git command on a list of repositories
+   get-tar-commit-id       Extract commit ID from an archive created using git-archive
+   ls-files                Show information about files in the index and the working tree
+   ls-remote               List references in a remote repository
+   ls-tree                 List the contents of a tree object
+   merge-base              Find as good common ancestors as possible for a merge
+   name-rev                Find symbolic names for given revs
+   pack-redundant          Find redundant pack files
+   rev-list                Lists commit objects in reverse chronological order
+   rev-parse               Pick out and massage parameters
+   show-index              Show packed archive index
+   show-ref                List references in a local repository
+   unpack-file             Creates a temporary file with a blob's contents
+   var                     Show a Git logical variable
+   verify-pack             Validate packed Git archive files
+
+Low-level Commands / Syncing Repositories
+   daemon                  A really simple server for Git repositories
+   fetch-pack              Receive missing objects from another repository
+   http-backend            Server side implementation of Git over HTTP
+   send-pack               Push objects over Git protocol to another repository
+   update-server-info      Update auxiliary info file to help dumb servers
+
+Low-level Commands / Internal Helpers
+   check-attr              Display gitattributes information
+   check-ignore            Debug gitignore / exclude files
+   check-mailmap           Show canonical names and email addresses of contacts
+   check-ref-format        Ensures that a reference name is well formed
+   column                  Display data in columns
+   credential              Retrieve and store user credentials
+   credential-cache        Helper to temporarily store passwords in memory
+   credential-store        Helper to store credentials on disk
+   fmt-merge-msg           Produce a merge commit message
+   hook                    Run git hooks
+   interpret-trailers      Add or parse structured information in commit messages
+   mailinfo                Extracts patch and authorship from a single e-mail message
+   mailsplit               Simple UNIX mbox splitter program
+   merge-one-file          The standard helper program to use with git-merge-index
+   patch-id                Compute unique ID for a patch
+   sh-i18n                 Git's i18n setup code for shell scripts
+   sh-setup                Common Git shell script setup code
+   stripspace              Remove unnecessary whitespace
+
+User-facing repository, command and file interfaces
+   attributes              Defining attributes per path
+   cli                     Git command-line interface and conventions
+   hooks                   Hooks used by Git
+   ignore                  Specifies intentionally untracked files to ignore
+   mailmap                 Map author/committer names and/or E-Mail addresses
+   modules                 Defining submodule properties
+   repository-layout       Git Repository Layout
+   revisions               Specifying revisions and ranges for Git
+
+Developer-facing file formats, protocols and other interfaces
+   format-bundle           The bundle file format
+   format-chunk            Chunk-based file formats
+   format-commit-graph     Git commit-graph format
+   format-index            Git index format
+   format-pack             Git pack format
+   format-signature        Git cryptographic signature formats
+   protocol-capabilities   Protocol v0 and v1 capabilities
+   protocol-common         Things common to various protocols
+   protocol-http           Git HTTP-based protocols
+   protocol-pack           How packs are transferred over-the-wire
+   protocol-v2             Git Wire Protocol, Version 2

--- a/spec/gitsh/hinter_spec.rb
+++ b/spec/gitsh/hinter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Igitsh::Hinter, :without_git do
       allow(Igitsh::Git).to receive(:command_names).and_return(%w[diff])
       allow(Igitsh::Git).to receive(:command_set).and_return(Set["diff"])
       allow(Igitsh::Git).to receive(:command_descriptions).and_call_original
+      allow(Igitsh::Git).to receive(:raw_command_descriptions).and_call_original
     end
 
     context "with Git command" do


### PR DESCRIPTION
Closes #41

This adds a message to the user about internal commands, help page support for internal commands and a new internal command `:commands` to list all internal and external commands.